### PR TITLE
Add GitHub

### DIFF
--- a/blinder.js
+++ b/blinder.js
@@ -27,6 +27,8 @@ Blinder.params = [
   'anonymousName',        // Placeholder text to blind candidate names with
   'anonymousNameForText', // Placeholder text for replacing a candidate name in a paragraph of text
   'anonymousEmail',       // Placeholder text to blind candidate emails with
+  'anonymousLocation',    // Placeholder text to blind candidate location with
+  'anonymousWebsite',     // Placeholder text to blind candidate location with
   'anonymousImgSrc',      // Source URL of a placeholder image. This is typically a per-site setting
 ];
 
@@ -34,6 +36,8 @@ Blinder.defaults = {
   anonymousName: 'A Candidate',
   anonymousNameForText: 'Candidate',
   anonymousEmail: 'hidden@example.com',
+  anonymousLocation: 'Anytown, Earth',
+  anonymousWebsite: 'https://www.google.com',
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -132,7 +136,7 @@ Blinder.prototype.blind = function (selectorOrElement, fn) {
   self.blindElement(element, fn);
 }
 
-// Invokes the given function on the given element (or the element matching the given seletor).
+// Invokes the given function on the given element (or the element matching the given selector).
 // Used to drill one level into the DOM tree.
 Blinder.prototype.blindElement = function (selectorOrElement, fn) {
   var element = this.lookupElementIfNeeded(selectorOrElement);
@@ -165,6 +169,18 @@ Blinder.prototype.blindName = function (selectorOrElement) {
 Blinder.prototype.blindEmail = function (selectorOrElement) {
   var element = this.lookupElementIfNeeded(selectorOrElement);
   if (element) element.textContent = this.options.anonymousEmail;
+}
+
+// Replaces the text of the given element with the configured anonymous location.
+Blinder.prototype.blindLocation = function (selectorOrElement) {
+  var element = this.lookupElementIfNeeded(selectorOrElement);
+  if (element) element.textContent = this.options.anonymousLocation;
+}
+
+// Replaces the text of the given element with the configured anonymous location.
+Blinder.prototype.blindWebsite = function (selectorOrElement) {
+  var element = this.lookupElementIfNeeded(selectorOrElement);
+  if (element) element.textContent = this.options.anonymousWebsite;
 }
 
 // Replaces the src property of the given image element with the configured anonymous image src

--- a/blinder.js
+++ b/blinder.js
@@ -177,7 +177,7 @@ Blinder.prototype.blindLocation = function (selectorOrElement) {
   if (element) element.textContent = this.options.anonymousLocation;
 }
 
-// Replaces the text of the given element with the configured anonymous location.
+// Replaces the text of the given element with the configured anonymous Website.
 Blinder.prototype.blindWebsite = function (selectorOrElement) {
   var element = this.lookupElementIfNeeded(selectorOrElement);
   if (element) element.textContent = this.options.anonymousWebsite;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Blind Audition",
-  "version": "0.5",
+  "version": "0.6",
   "description": "Anonymizes candidates on recruiting sites",
   "author": "Jason Crawford <jason@fieldbook.com>",
 
@@ -35,6 +35,10 @@
     {
       "matches": ["*://app.greenhouse.io/people/*"],
       "js": ["blinder.js", "sites/greenhouse.js"]
+    },
+    {
+      "matches": ["*://github.com/*"],
+      "js": ["blinder.js", "sites/github.js"]
     }
   ]
 }

--- a/sites/github.js
+++ b/sites/github.js
@@ -1,0 +1,58 @@
+var blinder = new Blinder({anonymousImgSrc: 'https://github.com/identicons/anyone.png'});
+
+var fullNameElement = document.querySelector('.vcard-fullname');
+var fullName = fullNameElement ? fullNameElement.innerText : false;
+
+var userNameElement = document.querySelector('.p-nickname');
+var username = userNameElement ? userNameElement.innerText : false;
+
+blinder.blind('body', function () {
+    // remove name from tab title
+    document.title = "Candidate Github Profile";
+
+    this.blindElements('.h-card', function () {
+        this.blindPic('.avatar');
+        this.blindName('.vcard-fullname');
+        // this.blindName('.p-nickname');
+        
+        this.blindEmail('.vcard-details [itemprop="email"]');
+        this.blindLocation('.vcard-details [itemprop="homeLocation"]');
+        this.blindWebsite('.vcard-details [itemprop="url"]');
+    })
+
+    // blind username in sticky bar
+    this.blindElements('.user-profile-sticky-bar', function () {
+        this.blindName('.user-profile-mini-vcard span strong');
+        this.blindPic('.avatar-user');
+    })
+
+    // blind avatar in PRs
+    this.blindElements('.pull-discussion-timeline', function () {
+        this.blindElements('.TimelineItem', function () {
+            this.blindPic('.avatar-user');
+        })
+        this.blindElements('.timeline-comment-group', function () {
+            this.blindName('.Link--primary');
+            this.blindPic('.avatar-user');
+        })
+    })
+
+    // Hide avatar in commits
+    this.blindElements('.TimelineItem-body', function () {      
+        this.blindElements('.Box-row', function () {
+            this.blindPic('.avatar-user img');
+        });
+    })
+
+    // Hide avatar in commits
+    this.blindElements('.AvatarStack-body', function () {      
+        this.blindPic('.avatar-user img');
+    })
+
+    // blind avatars in popups from hover actions
+    this.blindElements('.Popover', function () {
+        this.blindPic('.avatar-user');
+        this.blindName('.Link--primary');
+        this.blindName('.Link--secondary');
+    })
+});

--- a/sites/github.js
+++ b/sites/github.js
@@ -7,8 +7,9 @@ var userNameElement = document.querySelector('.p-nickname');
 var username = userNameElement ? userNameElement.innerText : false;
 
 blinder.blind('body', function () {
-    // remove name from tab title
+    // Remove name from tab title
     document.title = "Candidate Github Profile";
+    this.blindPic('.avatar');
 
     this.blindElements('.h-card', function () {
         this.blindPic('.avatar');
@@ -19,36 +20,44 @@ blinder.blind('body', function () {
         this.blindWebsite('.vcard-details [itemprop="url"]');
     })
 
-    // blind username in sticky bar
+    // Blind elements in sticky bar
     this.blindElements('.user-profile-sticky-bar', function () {
         this.blindName('.user-profile-mini-vcard span strong');
         this.blindPic('.avatar-user');
     })
 
-    // blind avatar in PRs
+    // Blind avatar in PRs
     this.blindElements('.pull-discussion-timeline', function () {
-        this.blindElements('.TimelineItem', function () {
-            this.blindPic('.avatar-user');
-        })
-        this.blindElements('.timeline-comment-group', function () {
-            this.blindName('.Link--primary');
-            this.blindPic('.avatar-user');
-        })
+        this.blindPic('.avatar-user img');
+        this.blindPic('.avatar-user');
+    })
+    
+    this.blindElements( '.participant-avatar', function() {
+        this.blindPic('.avatar-user');
     })
 
-    // Hide avatar in commits
+    // Hide avatar in commits & Issues
     this.blindElements('.TimelineItem-body', function () {      
-        this.blindElements('.Box-row', function () {
-            this.blindPic('.avatar-user img');
-        });
+        this.blindPic('.avatar-user');
+        this.blindPic('.avatar-user img');
     })
 
-    // Hide avatar in commits
     this.blindElements('.AvatarStack-body', function () {      
         this.blindPic('.avatar-user img');
     })
 
-    // blind avatars in popups from hover actions
+    this.blindElements('.TimelineItem-avatar', function () {      
+        this.blindPic('.avatar');
+        this.blindPic('img');
+    })
+
+    // PR sidebar
+    this.blindElements('.d-flex', function () {      
+        this.blindPic('.avatar');
+     })
+    
+
+    // Blind avatars in popups from hover actions
     this.blindElements('.Popover', function () {
         this.blindPic('.avatar-user');
         this.blindName('.Link--primary');

--- a/sites/github.js
+++ b/sites/github.js
@@ -13,7 +13,6 @@ blinder.blind('body', function () {
     this.blindElements('.h-card', function () {
         this.blindPic('.avatar');
         this.blindName('.vcard-fullname');
-        // this.blindName('.p-nickname');
         
         this.blindEmail('.vcard-details [itemprop="email"]');
         this.blindLocation('.vcard-details [itemprop="homeLocation"]');


### PR DESCRIPTION
Adds Github as a supported site.
Blinds avatars, name, location, website. Does not blind username because I feel lit make it difficult to see how a candidate participates in PRs and conversations. It could be a future improvement.